### PR TITLE
Convert urn:office[1] namespace tag into xhtml

### DIFF
--- a/chrome-devtools-client.lua
+++ b/chrome-devtools-client.lua
@@ -58,6 +58,8 @@ function Client.convert_html_to_xml(self, html)
 
   html = self:html_remove_double_hyphen(html)
   assert(html)
+  html = self:html_remove_office_p_tag(html)
+  assert(html)
   self:page_navigate("data:text/html;charset=UTF-8;base64,"..basexx.to_base64(html))
 
   local command = {
@@ -242,6 +244,12 @@ function Client.html_remove_double_hyphen(self, html)
     value = value.."\r\n"..v
   end
   return value
+end
+
+function Client.html_remove_office_p_tag(self, html)
+  pre = string.gsub(html, "<o:p", "<p")
+  post = string.gsub(pre, "/o:p>", "/p>")
+  return string.gsub(post, "\r?\n", "")
 end
 
 function Client.new(self)


### PR DESCRIPTION
[1] urn:schemas-microsoft-com:office:office
[2] http://www.w3.org/1999/xhtml

Typically we need to convert <o:p> into <p> to resolve namespace issue.